### PR TITLE
fix type

### DIFF
--- a/src/client/linux/handler/exception_handler.cc
+++ b/src/client/linux/handler/exception_handler.cc
@@ -138,7 +138,7 @@ void InstallAlternateStackLocked() {
   // SIGSTKSZ may be too small to prevent the signal handlers from overrunning
   // the alternative stack. Ensure that the size of the alternative stack is
   // large enough.
-  static const unsigned kSigStackSize = std::max(16384, SIGSTKSZ);
+  static const unsigned kSigStackSize = std::max(int64_t(16384), int64_t(SIGSTKSZ));
 
   // Only set an alternative stack if there isn't already one, or if the current
   // one is too small.


### PR DESCRIPTION
Hi, @driazati. When I build Pytorch from src, I meet an error:

../third_party/breakpad/src/client/linux/handler/exception_handler.cc:141:65: error: no matching function for call to ‘max(int, long int)’
static const unsigned kSigStackSize = std::max(16384, SIGSTKSZ);

And I find this "SIGSTKSZ" in a version of library is "long int", will you consider fix this?
